### PR TITLE
Use phusion/baseimage-docker as base

### DIFF
--- a/bamboo-server/Dockerfile
+++ b/bamboo-server/Dockerfile
@@ -2,28 +2,30 @@
 #
 # VERSION               0.0.1
 
-FROM hwuethrich/supervisord
+FROM phusion/baseimage:0.9.16
 MAINTAINER H. Wüthrich "hw@5px.ch"
 
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
 # Environment
-ENV BAMBOO_VERSION 5.4
+ENV BAMBOO_VERSION 5.7.2
 ENV BAMBOO_HOME /home/bamboo
-
-# Add startup script and supervisor config
-ADD bamboo-server.sh /start/bamboo-server
-ADD supervisor.conf /etc/supervisor/conf.d/bamboo-server.conf
-
-# Install Oracle Java 7
-RUN eatmydata -- apt-get install -yq python-software-properties && add-apt-repository ppa:webupd8team/java -y && apt-get update
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN eatmydata -- apt-get install -yq oracle-java7-installer
-
-# VCS tools
-RUN eatmydata -- apt-get install -yq git subversion
 
 # Expose web and agent ports
 EXPOSE 8085
 EXPOSE 54663
 
-# Run supervisord
-CMD ["/start/supervisord"]
+# Add startup script and supervisor config
+ADD bamboo-server.sh /etc/service/bamboo-service/run
+
+# Make sure we get latet packages
+RUN apt-get update && apt-get upgrade -y # 28.01.2015
+
+# Install Java OpenJDK 7 and VCS tools
+RUN apt-get install -yq python-software-properties && add-apt-repository ppa:webupd8team/java -y && apt-get update
+RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-get install -yq oracle-java7-installer git subversion
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/bamboo-server/README.md
+++ b/bamboo-server/README.md
@@ -1,6 +1,6 @@
 # Bamboo Server
 
-Docker image to install [Atlassian Bamboo](https://www.atlassian.com/software/bamboo) and run the server using [supervisord](http://supervisord.org/).
+Docker image to install [Atlassian Bamboo](https://www.atlassian.com/software/bamboo) based on [phusion/baseimage-docker](/phusion/baseimage-docker).
 
 ## Usage
 
@@ -21,7 +21,7 @@ docker run -p 8085:8085 -p 54663:54663 hwuethrich/bamboo-server
 
 If you want to use Bamboo remote agents, make sure to set the public port (and hostname) in the Bamboo settings (or directly in `/home/bamboo/bamboo.cfg.xml`).
 
-More info about port redirection can be found in the official Docker [documentation](http://docs.docker.io/en/latest/use/port_redirection/).
+More info about port redirection can be found in the official Docker [documentation](https://docs.docker.com/reference/run/#expose-incoming-ports).
 
 ### Persist `BAMBOO_HOME` on the docker host
 


### PR DESCRIPTION
It uses runit instead of supervisor but seems to be a more solid base for docker images.

See details [here](/phusion/baseimage-docker).