### PR TITLE
Adding MySQL Support

### DIFF
--- a/bamboo-server/Dockerfile
+++ b/bamboo-server/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER H. Wüthrich "hw@5px.ch"
 CMD ["/sbin/my_init"]
 
 # Environment
-ENV BAMBOO_VERSION 5.7.2
+ENV BAMBOO_VERSION 5.10.1.1
 ENV BAMBOO_HOME /home/bamboo
 
 # Expose web and agent ports
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get upgrade -y # 28.01.2015
 
 # Install Java OpenJDK 7 and VCS tools
 RUN apt-get install -yq python-software-properties && add-apt-repository ppa:webupd8team/java -y && apt-get update
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get install -yq oracle-java7-installer git subversion
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-get install -yq oracle-java8-installer git subversion
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/bamboo-server/bamboo-server.sh
+++ b/bamboo-server/bamboo-server.sh
@@ -24,7 +24,7 @@ else
   MYSQL_CONNECTOR_VERSION="5.1.38"
   wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.tar.gz -O /tmp/mysql-connector.tar.gz
   tar xzf /tmp/mysql-connector.tar.gz -C /tmp
-  mv /tmp/mysql-connector-java-$MYSQL_CONNECTOR_VERSION/mysql-connector-java-$MYSQL_CONNECTOR_VERSION-bin.jar /opt/atlassian-bamboo-5.1/lib/
+  mv /tmp/mysql-connector-java-$MYSQL_CONNECTOR_VERSION/mysql-connector-java-$MYSQL_CONNECTOR_VERSION-bin.jar $BAMBOO_DIR/lib/
   rm -Rf /tmp/*
 
   echo "-> Installation completed"

--- a/bamboo-server/bamboo-server.sh
+++ b/bamboo-server/bamboo-server.sh
@@ -20,7 +20,7 @@ else
   tar xzf /tmp/atlassian-bamboo.tar.gz -C /opt
   rm -f /tmp/atlassian-bamboo.tar.gz
   
-  echo "Add MySQL"
+  echo "Add MySQL Connector"
   MYSQL_CONNECTOR_VERSION="5.1.38"
   wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.tar.gz -O /tmp/mysql-connector.tar.gz
   tar xzf /tmp/mysql-connector.tar.gz -C /tmp

--- a/bamboo-server/bamboo-server.sh
+++ b/bamboo-server/bamboo-server.sh
@@ -20,8 +20,14 @@ else
   tar xzf /tmp/atlassian-bamboo.tar.gz -C /opt
   rm -f /tmp/atlassian-bamboo.tar.gz
   
+  
   echo "Add MySQL Connector"
-  MYSQL_CONNECTOR_VERSION="5.1.38"
+  
+  if [ -z $MYSQL_CONNECTOR_VERSION ]; then
+    echo "MYSQL_CONNECTOR_VERSION not set. Setting to 5.1.38"
+    MYSQL_CONNECTOR_VERSION=5.1.38
+  fi
+  
   wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.tar.gz -O /tmp/mysql-connector.tar.gz
   tar xzf /tmp/mysql-connector.tar.gz -C /tmp
   mv /tmp/mysql-connector-java-$MYSQL_CONNECTOR_VERSION/mysql-connector-java-$MYSQL_CONNECTOR_VERSION-bin.jar $BAMBOO_DIR/lib/

--- a/bamboo-server/bamboo-server.sh
+++ b/bamboo-server/bamboo-server.sh
@@ -19,6 +19,14 @@ else
   echo "-> Extracting to $BAMBOO_DIR ..."
   tar xzf /tmp/atlassian-bamboo.tar.gz -C /opt
   rm -f /tmp/atlassian-bamboo.tar.gz
+  
+  echo "Add MySQL"
+  MYSQL_CONNECTOR_VERSION="5.1.38"
+  wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.tar.gz -O /tmp/mysql-connector.tar.gz
+  tar xzf /tmp/mysql-connector.tar.gz -C /tmp
+  mv /tmp/mysql-connector-java-$MYSQL_CONNECTOR_VERSION/mysql-connector-java-$MYSQL_CONNECTOR_VERSION-bin.jar /opt/atlassian-bamboo-5.1/lib/
+  rm -Rf /tmp/*
+
   echo "-> Installation completed"
 fi
 


### PR DESCRIPTION
Hi!
I think this is very useful, because if we want to use Bamboo for production needing a mysql database. So it's nice to have the necessary mysql connector already installed. (It's just +1MB)
