### PR TITLE
Support reverse proxies that terminate HTTPS

### DIFF
--- a/bamboo-server/Dockerfile
+++ b/bamboo-server/Dockerfile
@@ -11,6 +11,7 @@ CMD ["/sbin/my_init"]
 # Environment
 ENV BAMBOO_VERSION 5.7.2
 ENV BAMBOO_HOME /home/bamboo
+ENV BAMBOO_SCHEME http 
 
 # Expose web and agent ports
 EXPOSE 8085
@@ -21,6 +22,9 @@ ADD bamboo-server.sh /etc/service/bamboo-server/run
 
 # Make sure we get latet packages
 RUN apt-get update && apt-get upgrade -y # 28.01.2015
+
+# Install xmlstarlet
+RUN apt-get install -yq xmlstarlet
 
 # Install Java OpenJDK 7 and VCS tools
 RUN apt-get install -yq python-software-properties && add-apt-repository ppa:webupd8team/java -y && apt-get update


### PR DESCRIPTION
Bamboo has a fair number of absolute URLs in it, not least redirects during setup. If you have a reverse proxy (such as Amazon's ELB) in front of a Bamboo server docker instance (such as on Amazon's ECS) without this patch, Bamboo will redirect you from HTTPS to HTTP constantly making the application unusable.

This patch allows you to specify the BAMBOO_SCHEME env var to either http or https (defaulting to https). We use xmlstarlet to set the appropriate connector attributes in the Tomcat server.xml file.
